### PR TITLE
Correction des tests pour la création et la suppression de la BDD

### DIFF
--- a/US_README/US-21_README.md
+++ b/US_README/US-21_README.md
@@ -24,5 +24,9 @@ Codage de la fonction deleteDB  + Vérification du test pour deleteDb
 
 Etape 7 :
 Modification de fonction createDb : toutes les colonnes  des tableaux sont à remplir ('not null')
+
+Etape 8 : 
+Problème sur les tests par l'ajout d'une table sqlite_sequence --> Correction faite
+
 =======
 # Quick Chat

--- a/tests/testBdd.py
+++ b/tests/testBdd.py
@@ -1,8 +1,8 @@
-import unittest
-import sqlite3
-from QuickChat_bdd import deleteDb
+import unittest, sqlite3, sys
+sys.path[:0] = ['../']
+import QuickChat_bdd
 from QuickChat_bdd import createDb
-
+from QuickChat_bdd import deleteDb
 
 class test_creation_delete_bdd(unittest.TestCase):
 
@@ -12,17 +12,22 @@ class test_creation_delete_bdd(unittest.TestCase):
 		self.connect = sqlite3.connect(self.db_path)
 		self.cursor = self.connect.cursor()
 
+#sqlite_sequence : table interne qui gère les AUTOINCREMENT + insupprimable
+
 	def test_createDb(self):
 		createDb(self.db_path)
 		sql = "SELECT name FROM sqlite_master WHERE type='table';"
-		#print(self.cursor.execute(sql).fetchall())
-		self.assertEqual(self.cursor.execute(sql).fetchall(), [('Room',), ('User',), ('Message',)])
+		res = self.cursor.execute(sql).fetchall()
+		self.assertIn(('Room',), res)
+		self.assertIn(('User',), res)
+		self.assertIn(('Message',), res)
+		self.assertIn(('sqlite_sequence',), res)
 
 	def test_deleteDb(self):
 		deleteDb(self.db_path)
 		sql = "SELECT name FROM sqlite_master WHERE type='table';"
 		#print(self.cursor.execute(sql).fetchall())
-		self.assertEqual(self.cursor.execute(sql).fetchall(), [])
+		self.assertEqual(self.cursor.execute(sql).fetchall(), [('sqlite_sequence',)])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Problème lors du lancement des tests causé par l'ajout d'une table `sqlite_sequence`. La table `sqlite_sequence` s'ajoute automatiquement lorsque `AUTOINCREMENT` est présent dans la définition de `id` des tables. Cette table ne s'efface pas lorsque l'on veut supprimer toutes les tables de la BDD.